### PR TITLE
feat: add paper_discovery message type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export * from './registry/capability.js';
 export * from './registry/peer.js';
 export * from './registry/peer-store.js';
 export * from './registry/messages.js';
+export * from './message/types/paper-discovery.js';
 export * from './transport/http.js';
 export * from './transport/peer-config.js';

--- a/src/message/envelope.ts
+++ b/src/message/envelope.ts
@@ -14,7 +14,8 @@ export type MessageType =
   | 'subscribe'     // Agent subscribes to a topic/domain
   | 'verify'        // Agent verifies another agent's claim
   | 'ack'           // Acknowledgement
-  | 'error';        // Error response
+  | 'error'         // Error response
+  | 'paper_discovery'; // Agent publishes a discovered academic paper
 
 /**
  * The signed envelope that wraps every message on the network.

--- a/src/message/types/paper-discovery.ts
+++ b/src/message/types/paper-discovery.ts
@@ -1,0 +1,27 @@
+/**
+ * Payload for 'paper_discovery' messages.
+ * An agent publishes a discovered academic paper to the network.
+ * Each paper gets its own envelope for easy referencing and threading.
+ */
+export interface PaperDiscoveryPayload {
+  /** arXiv identifier (e.g. "2501.12345") */
+  arxiv_id: string;
+  /** Paper title */
+  title: string;
+  /** List of author names */
+  authors: string[];
+  /** Key contribution in 1-2 sentences */
+  claim: string;
+  /** Confidence score (0-1) in the relevance/importance assessment */
+  confidence: number;
+  /** Tags describing relevance domains */
+  relevance_tags: string[];
+  /** Agent ID of the discoverer */
+  discoverer: string;
+  /** ISO 8601 timestamp of discovery */
+  timestamp: string;
+  /** URL to the abstract page */
+  abstract_url: string;
+  /** URL to the PDF (optional) */
+  pdf_url?: string;
+}

--- a/test/paper-discovery.test.ts
+++ b/test/paper-discovery.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { generateKeyPair } from '../src/identity/keypair.js';
+import { createEnvelope, verifyEnvelope } from '../src/message/envelope.js';
+import type { PaperDiscoveryPayload } from '../src/message/types/paper-discovery.js';
+
+describe('PaperDiscoveryPayload', () => {
+  const samplePayload: PaperDiscoveryPayload = {
+    arxiv_id: '2501.12345',
+    title: 'Attention Is All You Need (Again)',
+    authors: ['Alice Researcher', 'Bob Scientist'],
+    claim: 'Introduces a novel sparse attention mechanism that reduces transformer inference cost by 10x while maintaining accuracy.',
+    confidence: 0.92,
+    relevance_tags: ['transformers', 'efficiency', 'attention'],
+    discoverer: 'hephaestus',
+    timestamp: '2025-07-11T12:00:00Z',
+    abstract_url: 'https://arxiv.org/abs/2501.12345',
+    pdf_url: 'https://arxiv.org/pdf/2501.12345',
+  };
+
+  it('should create a valid paper_discovery envelope', () => {
+    const kp = generateKeyPair();
+    const envelope = createEnvelope('paper_discovery', kp.publicKey, kp.privateKey, samplePayload);
+
+    assert.strictEqual(envelope.type, 'paper_discovery');
+    assert.strictEqual(envelope.sender, kp.publicKey);
+    assert.ok(envelope.id);
+    assert.ok(envelope.signature);
+    assert.ok(envelope.timestamp > 0);
+    assert.deepStrictEqual(envelope.payload, samplePayload);
+  });
+
+  it('should verify a valid paper_discovery envelope', () => {
+    const kp = generateKeyPair();
+    const envelope = createEnvelope('paper_discovery', kp.publicKey, kp.privateKey, samplePayload);
+
+    const result = verifyEnvelope(envelope);
+    assert.strictEqual(result.valid, true);
+    assert.strictEqual(result.reason, undefined);
+  });
+
+  it('should reject a tampered paper_discovery payload', () => {
+    const kp = generateKeyPair();
+    const envelope = createEnvelope('paper_discovery', kp.publicKey, kp.privateKey, samplePayload);
+
+    const tampered = { ...envelope, payload: { ...samplePayload, confidence: 0.1 } };
+    const result = verifyEnvelope(tampered);
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.reason, 'id_mismatch');
+  });
+
+  it('should work without optional pdf_url', () => {
+    const { pdf_url: _, ...payloadWithoutPdf } = samplePayload;
+    const kp = generateKeyPair();
+    const envelope = createEnvelope('paper_discovery', kp.publicKey, kp.privateKey, payloadWithoutPdf);
+
+    assert.strictEqual(envelope.type, 'paper_discovery');
+    assert.strictEqual(envelope.payload.pdf_url, undefined);
+
+    const result = verifyEnvelope(envelope);
+    assert.strictEqual(result.valid, true);
+  });
+
+  it('should preserve all payload fields through envelope creation', () => {
+    const kp = generateKeyPair();
+    const envelope = createEnvelope('paper_discovery', kp.publicKey, kp.privateKey, samplePayload);
+
+    const p = envelope.payload as PaperDiscoveryPayload;
+    assert.strictEqual(p.arxiv_id, '2501.12345');
+    assert.strictEqual(p.title, 'Attention Is All You Need (Again)');
+    assert.deepStrictEqual(p.authors, ['Alice Researcher', 'Bob Scientist']);
+    assert.strictEqual(p.confidence, 0.92);
+    assert.deepStrictEqual(p.relevance_tags, ['transformers', 'efficiency', 'attention']);
+    assert.strictEqual(p.discoverer, 'hephaestus');
+    assert.strictEqual(p.timestamp, '2025-07-11T12:00:00Z');
+    assert.strictEqual(p.abstract_url, 'https://arxiv.org/abs/2501.12345');
+    assert.strictEqual(p.pdf_url, 'https://arxiv.org/pdf/2501.12345');
+  });
+
+  it('should support inReplyTo for threaded discussion', () => {
+    const kp = generateKeyPair();
+    const original = createEnvelope('paper_discovery', kp.publicKey, kp.privateKey, samplePayload);
+    const reply = createEnvelope('response', kp.publicKey, kp.privateKey, { comment: 'Interesting paper!' }, original.id);
+
+    assert.strictEqual(reply.inReplyTo, original.id);
+    const result = verifyEnvelope(reply);
+    assert.strictEqual(result.valid, true);
+  });
+
+  it('should reject impersonation of paper discoverer', () => {
+    const real = generateKeyPair();
+    const impersonator = generateKeyPair();
+
+    const envelope = createEnvelope('paper_discovery', real.publicKey, impersonator.privateKey, samplePayload);
+    const result = verifyEnvelope(envelope);
+    assert.strictEqual(result.valid, false);
+    assert.strictEqual(result.reason, 'signature_invalid');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `paper_discovery` message type to Agora, enabling agents to share academic paper discoveries on the network.

Closes #11

### Changes

- **`src/message/types/paper-discovery.ts`** — New `PaperDiscoveryPayload` interface with fields: `arxiv_id`, `title`, `authors`, `claim`, `confidence` (0-1), `relevance_tags`, `discoverer`, `timestamp`, `abstract_url`, and optional `pdf_url`
- **`src/message/envelope.ts`** — Added `'paper_discovery'` to the `MessageType` union
- **`src/index.ts`** — Re-exported the new type
- **`test/paper-discovery.test.ts`** — 7 tests covering envelope creation, verification, tamper detection, optional fields, threading via `inReplyTo`, and impersonation rejection

### Design Decision

One envelope per paper (individual envelopes), as discussed in the issue — easier to reference and reply to specific discoveries.

### Tests

All 7 new tests pass. The 23 pre-existing CLI test failures are unrelated (present on `main`).